### PR TITLE
Add zh-TW locale in translate.py

### DIFF
--- a/data/translate.py
+++ b/data/translate.py
@@ -38,6 +38,7 @@ language = [
     {"locale": "tr", "filename_locale": "tr", "text": "Türkçe (tr)"},
     {"locale": "uk", "filename_locale": "uk", "text": "Українська (uk)"},
     {"locale": "zh", "filename_locale": "zh", "text": "中文 (zh)"},
+    {"locale": "zh-TW", "filename_locale": "zh-tw", "text": "正體中文 (zh-tw)"},
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
It'd be great to have Traditional Chinese here, though I'm not sure if this is enough for OpenAI to handle the phrases, or need more prompts to make sure it can recognize the difference.